### PR TITLE
Potential fix for code scanning alert no. 1: Shell command built from environment values

### DIFF
--- a/scripts/build-server.ts
+++ b/scripts/build-server.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import { config, parse } from 'dotenv';
 import { build } from 'esbuild';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
@@ -41,11 +41,14 @@ if (existsSync('.env')) {
     console.log('✅ esbuild done');
 
     const outputFile = path.resolve('src-tauri/binaries/server-x86_64-pc-windows-msvc.exe');
-    const pkgCmd = `pkg ${outfile} --targets ${target}-win-x64 --output ${outputFile} --assets "node_modules/prismarine-nbt/**/*"`;
-    console.log('⚙️ Running:', pkgCmd);
-
-    console.log('⚙️ Running:', pkgCmd);
-    execSync(pkgCmd, { stdio: 'inherit' });
+    const pkgArgs = [
+      outfile,
+      '--targets', `${target}-win-x64`,
+      '--output', outputFile,
+      '--assets', 'node_modules/prismarine-nbt/**/*'
+    ];
+    console.log('⚙️ Running: pkg', ...pkgArgs);
+    execFileSync('pkg', pkgArgs, { stdio: 'inherit' });
     console.log('✅ pkg done, output at', outputFile);
 
     const iconPath = path.resolve('src-client/src/assets/imgs/favicon.ico');


### PR DESCRIPTION
Potential fix for [https://github.com/ALR2310/ALauncher/security/code-scanning/1](https://github.com/ALR2310/ALauncher/security/code-scanning/1)

To resolve the issue, we should avoid building the shell command as a string and passing it to the shell. Instead, we should call the underlying tool (`pkg`) directly (using `execFileSync` or similar), providing the arguments as an array. This will remove the risk of shell interpretation of any special characters in the file paths. 

- On line 44, rather than constructing a string like `"pkg ..."` (with all arguments interpolated), we should produce an array of arguments, e.g. `["pkg", outfile, "--targets", ..., "--output", outputFile, ...]`.
- Replace the call to `execSync(pkgCmd, ...)` with a call to `execFileSync`, specifying the command and its arguments independently. 
- Import `execFileSync` from `child_process` (do not remove `execSync` if it's used elsewhere in the file, but here we need it).
- Update the logging appropriately to show the command and its arguments.

We only need to update the relevant region (lines 43–48) in `scripts/build-server.ts`, and add the import for `execFileSync`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
